### PR TITLE
Fix artwork sync flooding, add skip-unchanged and force-replace options

### DIFF
--- a/Jellyfin.Plugin.Plexyfin/Api/PlexyfinController.cs
+++ b/Jellyfin.Plugin.Plexyfin/Api/PlexyfinController.cs
@@ -219,6 +219,10 @@ namespace Jellyfin.Plugin.Plexyfin.Api
         // Static field to track ongoing sync operations
         private static readonly Dictionary<string, SyncStatus> ActiveSyncs = new Dictionary<string, SyncStatus>();
 
+        // Tracks how many artwork downloads were skipped in the current sync run because the
+        // local file was already at least as new as Plex's reported "updatedAt" timestamp.
+        private int _artworkSkippedCount;
+
         /// <summary>
         /// Executes an async operation with retry logic for IOException (file locking issues).
         /// Uses exponential backoff between retries.
@@ -254,6 +258,43 @@ namespace Jellyfin.Plugin.Plexyfin.Api
                     await Task.Delay(delayMs).ConfigureAwait(false);
                 }
             }
+        }
+
+        /// <summary>
+        /// Runs an async operation over a list of items with a hard cap on how many run at the
+        /// same time, instead of firing all of them at once. This is the key lever for how much
+        /// concurrent load Plexyfin puts on the Plex server (simultaneous HTTP downloads) and on
+        /// Jellyfin (simultaneous image saves / database writes) during a sync. Without a cap,
+        /// a single TV series with, say, 200 episodes would fire 200 simultaneous requests at
+        /// both servers the moment that series was reached.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source items.</typeparam>
+        /// <typeparam name="TResult">The type of result each operation produces.</typeparam>
+        /// <param name="items">The items to process.</param>
+        /// <param name="maxConcurrency">The maximum number of operations allowed to run at once (clamped to at least 1).</param>
+        /// <param name="action">The async operation to run for each item.</param>
+        /// <returns>The results of each operation, in the same order as <paramref name="items"/>.</returns>
+        private static async Task<TResult[]> ProcessWithLimitedConcurrencyAsync<TSource, TResult>(
+            IEnumerable<TSource> items,
+            int maxConcurrency,
+            Func<TSource, Task<TResult>> action)
+        {
+            using var semaphore = new SemaphoreSlim(Math.Max(1, maxConcurrency));
+
+            var tasks = items.Select(async item =>
+            {
+                await semaphore.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    return await action(item).ConfigureAwait(false);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            });
+
+            return await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -347,6 +388,14 @@ namespace Jellyfin.Plugin.Plexyfin.Api
         {
             var config = Plugin.Instance!.Configuration;
             var result = new SyncResult();
+            _artworkSkippedCount = 0;
+
+            if (config.ForceReplaceAllArtwork && config.SyncItemArtwork)
+            {
+                _logger.LogWarning(
+                    "Force Replace All Artwork is ENABLED -- every item's artwork will be re-downloaded and replaced " +
+                    "this run (and every run) until this option is turned back off in the plugin settings.");
+            }
 
             // If this is a dry run, initialize the details collection
             if (dryRun)
@@ -551,6 +600,12 @@ namespace Jellyfin.Plugin.Plexyfin.Api
                 syncStatus.Message = completionMessage;
                 syncStatus.Progress = 100;
                 syncStatus.EndTime = DateTime.UtcNow;
+            }
+
+            result.ArtworkSkipped = _artworkSkippedCount;
+            if (_artworkSkippedCount > 0)
+            {
+                _logger.LogArtworkSkippedSummary(_artworkSkippedCount);
             }
 
             return result;
@@ -1000,7 +1055,7 @@ namespace Jellyfin.Plugin.Plexyfin.Api
             try
             {
                 // Process primary image (poster/thumbnail)
-                if (plexCollection.ThumbUrl != null)
+                if (plexCollection.ThumbUrl != null && !IsArtworkUpToDate(jellyfinCollection, ImageType.Primary, plexCollection.UpdatedAt))
                 {
                     _logger.LogDownloadingThumbnail("collection", plexCollection.ThumbUrl.ToString());
 
@@ -1083,7 +1138,7 @@ namespace Jellyfin.Plugin.Plexyfin.Api
                 }
 
                 // Process background image (art)
-                if (plexCollection.ArtUrl != null)
+                if (plexCollection.ArtUrl != null && !IsArtworkUpToDate(jellyfinCollection, ImageType.Backdrop, plexCollection.UpdatedAt))
                 {
                     _logger.LogDownloadingArt(plexCollection.ArtUrl.ToString());
 
@@ -1309,6 +1364,99 @@ namespace Jellyfin.Plugin.Plexyfin.Api
         }
 
         /// <summary>
+        /// Determines whether the existing local artwork for a Jellyfin item is already up to
+        /// date relative to the Plex item's "updatedAt" timestamp, so the delete/redownload
+        /// cycle can be skipped. This avoids the unnecessary network and disk I/O that would
+        /// otherwise occur on every sync run for the vast majority of items whose artwork
+        /// hasn't changed in Plex.
+        /// </summary>
+        /// <remarks>
+        /// This also correctly picks up artwork refreshed by external tools such as Kometa
+        /// (formerly Plex Meta Manager): whenever Kometa updates a poster or backdrop (for
+        /// example, to add a "Trending" or "Ended" overlay), Plex bumps the item's
+        /// "updatedAt" value, which makes it newer than the local file and forces a refresh.
+        /// </remarks>
+        /// <param name="jellyfinItem">The Jellyfin item whose artwork is being considered.</param>
+        /// <param name="imageType">The type of image being checked (Primary or Backdrop).</param>
+        /// <param name="plexUpdatedAt">The last-updated timestamp reported by Plex for the source item.</param>
+        /// <returns>True if the local artwork is already current and the download can be skipped.</returns>
+        private bool IsArtworkUpToDate(BaseItem jellyfinItem, ImageType imageType, DateTimeOffset? plexUpdatedAt)
+        {
+            // If Plex didn't report a timestamp, or the optimization is disabled, always refresh
+            // to be safe -- we'd rather do an unnecessary download than miss a real change.
+            if (plexUpdatedAt == null)
+            {
+                return false;
+            }
+
+            var config = Plugin.Instance?.Configuration;
+            if (config == null || !config.SkipUnchangedArtwork)
+            {
+                return false;
+            }
+
+            // Manual override: the user has asked to force a full artwork replace, so ignore
+            // the skip check entirely and always report "not up to date" until they turn this
+            // back off.
+            if (config.ForceReplaceAllArtwork)
+            {
+                return false;
+            }
+
+            List<ItemImageInfo> existingImages;
+            try
+            {
+                existingImages = jellyfinItem.GetImages(imageType).ToList();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error reading existing {0} images for {1}, will re-download", imageType, jellyfinItem.Name);
+                return false;
+            }
+
+            if (existingImages.Count == 0)
+            {
+                // Nothing local yet -- must download.
+                return false;
+            }
+
+            foreach (var image in existingImages)
+            {
+                if (!image.IsLocalFile || string.IsNullOrEmpty(image.Path))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (!System.IO.File.Exists(image.Path))
+                    {
+                        continue;
+                    }
+
+                    var localWriteTimeUtc = System.IO.File.GetLastWriteTimeUtc(image.Path);
+
+                    if (localWriteTimeUtc >= plexUpdatedAt.Value.UtcDateTime)
+                    {
+                        _logger.LogSkippingUnchangedArtwork(jellyfinItem.Name, imageType.ToString(), localWriteTimeUtc, plexUpdatedAt.Value.UtcDateTime);
+                        _artworkSkippedCount++;
+                        return true;
+                    }
+                }
+                catch (IOException ex)
+                {
+                    _logger.LogWarning(ex, "Could not read last write time for {0} image file: {1}", imageType, image.Path);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    _logger.LogWarning(ex, "Access denied reading last write time for {0} image file: {1}", imageType, image.Path);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Processes artwork for an individual episode.
         /// </summary>
         /// <param name="series">The Jellyfin TV series.</param>
@@ -1339,7 +1487,7 @@ namespace Jellyfin.Plugin.Plexyfin.Api
             try
             {
                 // Process episode thumbnail
-                if (plexEpisode.ThumbUrl != null)
+                if (plexEpisode.ThumbUrl != null && !IsArtworkUpToDate(jellyEpisode, ImageType.Primary, plexEpisode.UpdatedAt))
                 {
                     // Clear existing Primary images before saving the new one
                     await ClearItemImages(jellyEpisode, ImageType.Primary).ConfigureAwait(false);
@@ -1440,7 +1588,7 @@ namespace Jellyfin.Plugin.Plexyfin.Api
             try
             {
                 // Process primary image (poster/thumbnail) for the season
-                if (plexSeason.ThumbUrl != null)
+                if (plexSeason.ThumbUrl != null && !IsArtworkUpToDate(jellySeason, ImageType.Primary, plexSeason.UpdatedAt))
                 {
                     _logger.LogInformation("Downloading season thumbnail: {0}", plexSeason.ThumbUrl.ToString());
 
@@ -1521,7 +1669,7 @@ namespace Jellyfin.Plugin.Plexyfin.Api
                 }
 
                 // Process backdrop image for the season (if available)
-                if (plexSeason.ArtUrl != null)
+                if (plexSeason.ArtUrl != null && !IsArtworkUpToDate(jellySeason, ImageType.Backdrop, plexSeason.UpdatedAt))
                 {
                     _logger.LogInformation("Downloading season backdrop: {0}", plexSeason.ArtUrl.ToString());
 
@@ -1601,7 +1749,9 @@ namespace Jellyfin.Plugin.Plexyfin.Api
                     }
                 }
 
-                // Refresh artwork after changes
+                // Persist the change immediately -- this is what actually writes the new image
+                // info to Jellyfin's database, not just a notification, so it must happen right
+                // after saving while our in-memory item reference is still current.
                 if (hasChanges)
                 {
                     await _libraryManager.UpdateItemAsync(
@@ -1776,7 +1926,9 @@ namespace Jellyfin.Plugin.Plexyfin.Api
                     hasChanges = artworkCount > 0;
                 }
 
-                // Refresh artwork after changes
+                // Persist the change immediately -- this is what actually writes the new image
+                // info to Jellyfin's database, not just a notification, so it must happen right
+                // after saving while our in-memory item reference is still current.
                 if (hasChanges)
                 {
                     await _libraryManager.UpdateItemAsync(
@@ -1825,7 +1977,7 @@ namespace Jellyfin.Plugin.Plexyfin.Api
             try
             {
                 // Process primary image (poster/thumbnail)
-                if (plexItem.ThumbUrl != null)
+                if (plexItem.ThumbUrl != null && !IsArtworkUpToDate(jellyfinItem, ImageType.Primary, plexItem.UpdatedAt))
                 {
                     _logger.LogDownloadingThumbnail("item", plexItem.ThumbUrl.ToString());
 
@@ -1911,7 +2063,7 @@ namespace Jellyfin.Plugin.Plexyfin.Api
                 }
 
                 // Process background image (art)
-                if (plexItem.ArtUrl != null)
+                if (plexItem.ArtUrl != null && !IsArtworkUpToDate(jellyfinItem, ImageType.Backdrop, plexItem.UpdatedAt))
                 {
                     _logger.LogDownloadingItemArt("item", plexItem.ArtUrl.ToString());
 
@@ -2031,8 +2183,15 @@ namespace Jellyfin.Plugin.Plexyfin.Api
 
                 // Get episodes from Plex
                 var plexEpisodes = await plexClient.GetTvSeriesEpisodes(plexSeriesId).ConfigureAwait(false);
-                var tasks = plexEpisodes.ToList().Select(ep => ProcessEpisodeArtwork(series, ep)).ToList();
-                var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                // Process episodes with bounded concurrency instead of all at once -- a series
+                // can easily have 100+ episodes, and firing all of them simultaneously at Plex
+                // and Jellyfin is exactly the kind of API flooding we want to avoid.
+                var maxConcurrency = Plugin.Instance?.Configuration.MaxConcurrentApiRequests ?? 3;
+                var results = await ProcessWithLimitedConcurrencyAsync(
+                    plexEpisodes,
+                    maxConcurrency,
+                    ep => ProcessEpisodeArtwork(series, ep)).ConfigureAwait(false);
                 processedEpisodes += results.Count(success => success);
             }
             catch (Exception ex)
@@ -2071,8 +2230,14 @@ namespace Jellyfin.Plugin.Plexyfin.Api
                 // Get seasons from Plex
                 var plexSeasons = await plexClient.GetTvSeriesSeasons(plexSeriesId).ConfigureAwait(false);
                 _logger.LogInformation("Found {0} seasons for TV series {1}", plexSeasons.Count, series.Name);
-                var tasks = plexSeasons.ToList().Select(plexSeason => ProcessSeasonArtwork(series, plexSeason)).ToList();
-                var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                // Process seasons with bounded concurrency instead of all at once, for the same
+                // reason as episodes above.
+                var maxConcurrency = Plugin.Instance?.Configuration.MaxConcurrentApiRequests ?? 3;
+                var results = await ProcessWithLimitedConcurrencyAsync(
+                    plexSeasons,
+                    maxConcurrency,
+                    plexSeason => ProcessSeasonArtwork(series, plexSeason)).ConfigureAwait(false);
                 processedSeasons += results.Count(success => success);
 
                 _logger.LogInformation("Processed artwork for {0} seasons of {1}", processedSeasons, series.Name);
@@ -2197,72 +2362,102 @@ namespace Jellyfin.Plugin.Plexyfin.Api
                     int totalItems = plexItems.Count;
                     int processedItems = 0;
 
-                    // True parallel processing with fixed concurrency using SemaphoreSlim
-                    using (var semaphore = new SemaphoreSlim(config.SyncBatchSize > 0 ? config.SyncBatchSize : 5))
-                    {
-                        var tasks = new List<Task>();
-                        foreach (var plexItem in plexItems)
-                        {
-                            await semaphore.WaitAsync().ConfigureAwait(false);
-                            processedItems++;
-                            if (syncStatus != null && totalItems > 0 && processedItems % 10 == 0)
-                            {
-                                syncStatus.Message = $"Processing library {processedLibraries} of {totalLibraries}: " +
-                                                   $"Item {processedItems} of {totalItems} ({plexItem.Title})";
-                            }
-                            _logger.LogProcessingItemArtwork(plexItem.Title);
-                            var jellyfinItem = jellyfinIndex.FindMatch(plexItem);
-                            if (jellyfinItem != null)
-                            {
-                                _logger.LogMatchedItem(plexItem.Title, jellyfinItem.Id);
+                    // How many items to work on at the same time. This is deliberately a small,
+                    // dedicated setting (default 3) -- NOT the batch size below -- because it
+                    // directly controls how many simultaneous HTTP requests hit the Plex server
+                    // and how many simultaneous image saves/database writes hit Jellyfin.
+                    int maxConcurrency = config.MaxConcurrentApiRequests > 0 ? config.MaxConcurrentApiRequests : 3;
 
-                                // Check if we've already processed artwork for this Jellyfin item
-                                // (handles multiple Plex versions mapping to same Jellyfin item)
-                                if (processedJellyfinItems.Contains(jellyfinItem.Id))
+                    // How many items make up one batch. Items are processed batch by batch, with
+                    // a short pause in between, instead of queuing the entire library at once.
+                    // Combined with the concurrency cap above, this keeps load on Plex/Jellyfin
+                    // smooth and predictable even for very large libraries.
+                    int batchSize = config.SyncBatchSize > 0 ? config.SyncBatchSize : 25;
+                    var itemBatches = plexItems.Chunk(batchSize).ToList();
+
+                    // How long to pause between batches (milliseconds). User-configurable so
+                    // people can tune how gentle/fast the sync is on their setup.
+                    int batchDelayMs = config.BatchDelayMilliseconds >= 0 ? config.BatchDelayMilliseconds : 750;
+
+                    for (int batchIndex = 0; batchIndex < itemBatches.Count; batchIndex++)
+                    {
+                        var itemBatch = itemBatches[batchIndex];
+
+                        using (var semaphore = new SemaphoreSlim(maxConcurrency))
+                        {
+                            var tasks = new List<Task>();
+                            foreach (var plexItem in itemBatch)
+                            {
+                                await semaphore.WaitAsync().ConfigureAwait(false);
+                                processedItems++;
+                                if (syncStatus != null && totalItems > 0 && processedItems % 10 == 0)
                                 {
-                                    _logger.LogDebug("Already processed artwork for Jellyfin item '{0}' (ID: {1}), skipping duplicate", 
-                                        jellyfinItem.Name, jellyfinItem.Id);
-                                    semaphore.Release();
+                                    syncStatus.Message = $"Processing library {processedLibraries} of {totalLibraries}: " +
+                                                       $"Item {processedItems} of {totalItems} ({plexItem.Title})";
                                 }
-                                else
+                                _logger.LogProcessingItemArtwork(plexItem.Title);
+                                var jellyfinItem = jellyfinIndex.FindMatch(plexItem);
+                                if (jellyfinItem != null)
                                 {
-                                    // Process artwork for this item
-                                    if (!dryRun)
+                                    _logger.LogMatchedItem(plexItem.Title, jellyfinItem.Id);
+
+                                    // Check if we've already processed artwork for this Jellyfin item
+                                    // (handles multiple Plex versions mapping to same Jellyfin item)
+                                    if (processedJellyfinItems.Contains(jellyfinItem.Id))
                                     {
-                                        var task = Task.Run(async () => {
-                                            try
-                                            {
-                                                await ProcessItemArtwork(jellyfinItem, plexItem).ConfigureAwait(false);
-                                                lock (processedJellyfinItems)
-                                                {
-                                                    processedJellyfinItems.Add(jellyfinItem.Id);
-                                                }
-                                            }
-                                            catch (Exception ex)
-                                            {
-                                                _logger.LogErrorProcessingArtwork("item", plexItem.Title, ex);
-                                            }
-                                            finally
-                                            {
-                                                semaphore.Release();
-                                            }
-                                        });
-                                        tasks.Add(task);
+                                        _logger.LogDebug("Already processed artwork for Jellyfin item '{0}' (ID: {1}), skipping duplicate", 
+                                            jellyfinItem.Name, jellyfinItem.Id);
+                                        semaphore.Release();
                                     }
                                     else
                                     {
-                                        semaphore.Release();
+                                        // Process artwork for this item
+                                        if (!dryRun)
+                                        {
+                                            var task = Task.Run(async () => {
+                                                try
+                                                {
+                                                    await ProcessItemArtwork(jellyfinItem, plexItem).ConfigureAwait(false);
+                                                    lock (processedJellyfinItems)
+                                                    {
+                                                        processedJellyfinItems.Add(jellyfinItem.Id);
+                                                    }
+                                                }
+                                                catch (Exception ex)
+                                                {
+                                                    _logger.LogErrorProcessingArtwork("item", plexItem.Title, ex);
+                                                }
+                                                finally
+                                                {
+                                                    semaphore.Release();
+                                                }
+                                            });
+                                            tasks.Add(task);
+                                        }
+                                        else
+                                        {
+                                            semaphore.Release();
+                                        }
+                                        artworkUpdated++;
                                     }
-                                    artworkUpdated++;
+                                }
+                                else
+                                {
+                                    _logger.LogNoMatchItem(plexItem.Title);
+                                    semaphore.Release();
                                 }
                             }
-                            else
-                            {
-                                _logger.LogNoMatchItem(plexItem.Title);
-                                semaphore.Release();
-                            }
+                            await Task.WhenAll(tasks).ConfigureAwait(false);
                         }
-                        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                        // Give Plex and Jellyfin a short breather between batches instead of
+                        // immediately hammering them with the next one. Skipped after the last
+                        // batch (nothing to wait for), during dry runs (no requests were made),
+                        // and when the user has set the delay to 0.
+                        if (!dryRun && batchDelayMs > 0 && batchIndex < itemBatches.Count - 1)
+                        {
+                            await Task.Delay(batchDelayMs).ConfigureAwait(false);
+                        }
                     }
 
                     _logger.LogLibraryArtworkComplete(libraryId, artworkUpdated);

--- a/Jellyfin.Plugin.Plexyfin/Api/SyncResult.cs
+++ b/Jellyfin.Plugin.Plexyfin/Api/SyncResult.cs
@@ -27,6 +27,12 @@ namespace Jellyfin.Plugin.Plexyfin.Api
         /// Gets or sets the number of items with artwork updated.
         /// </summary>
         public int ItemArtworkUpdated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of artwork downloads skipped because the local file was
+        /// already at least as new as the corresponding Plex item's "updatedAt" timestamp.
+        /// </summary>
+        public int ArtworkSkipped { get; set; }
         
         /// <summary>
         /// Gets or sets detailed information about the sync operation.

--- a/Jellyfin.Plugin.Plexyfin/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Plexyfin/Configuration/PluginConfiguration.cs
@@ -20,8 +20,12 @@ namespace Jellyfin.Plugin.Plexyfin.Configuration
             SyncCollections = true;
             SyncArtwork = true; // Default to syncing artwork
             SyncItemArtwork = false; // Default to not syncing item artwork (opt-in feature)
+            SkipUnchangedArtwork = true; // Default to skipping re-download of artwork that Plex hasn't updated
+            ForceReplaceAllArtwork = false; // Default off -- opt-in override to bypass the skip check above
             EnableScheduledSync = false;
-            SyncBatchSize = 50; // Default batch size for processing
+            SyncBatchSize = 50; // Default number of items per processing batch
+            MaxConcurrentApiRequests = 3; // Default cap on simultaneous Plex/Jellyfin requests
+            BatchDelayMilliseconds = 750; // Default pause between batches
             SyncIntervalHours = 24; // Default to daily sync
             SelectedLibraries = new List<string>(); // Initialize with empty list
             EnableDebugMode = false; // Default to no debug mode
@@ -53,6 +57,27 @@ namespace Jellyfin.Plugin.Plexyfin.Configuration
         /// Gets or sets a value indicating whether to sync movie and TV show artwork.
         /// </summary>
         public bool SyncItemArtwork { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether artwork downloads should be skipped when
+        /// the local image file is already at least as new as the Plex item's "updatedAt"
+        /// timestamp. This avoids unnecessary network and disk I/O on every sync run, while
+        /// still picking up genuine changes -- including artwork refreshed by tools like
+        /// Kometa (formerly Plex Meta Manager), which bump Plex's "updatedAt" value whenever
+        /// they update a poster or backdrop.
+        /// </summary>
+        public bool SkipUnchangedArtwork { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore <see cref="SkipUnchangedArtwork"/>
+        /// and re-download and replace every piece of artwork on the next sync(s), regardless
+        /// of whether the local file already looks up to date. Use this to force a full refresh
+        /// (for example, after changing artwork settings, or if you suspect local images are out
+        /// of sync with Plex). Remember to turn this back off afterwards -- while it stays
+        /// enabled, every sync run will re-download and replace all artwork every time, which
+        /// is exactly the heavy behavior <see cref="SkipUnchangedArtwork"/> exists to avoid.
+        /// </summary>
+        public bool ForceReplaceAllArtwork { get; set; }
         
         /// <summary>
         /// Gets or sets a value indicating whether to automatically sync on a schedule.
@@ -60,9 +85,30 @@ namespace Jellyfin.Plugin.Plexyfin.Configuration
         public bool EnableScheduledSync { get; set; }
 
         /// <summary>
-        /// Batch size for processing items during sync operations.
+        /// Gets or sets the number of items processed per batch during item-artwork sync.
+        /// Items are worked through batch by batch, with a short pause between batches, rather
+        /// than queuing an entire library at once. This does NOT control how many requests run
+        /// at the same time -- see <see cref="MaxConcurrentApiRequests"/> for that.
         /// </summary>
         public int SyncBatchSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of items processed at the same time during
+        /// item-artwork sync (movies/shows, and their seasons/episodes). This is the main
+        /// control for how much simultaneous load Plexyfin puts on the Plex server (concurrent
+        /// HTTP downloads) and on Jellyfin (concurrent image saves and database writes). Keep
+        /// this low (2-5) unless you know your servers can comfortably handle more; high values
+        /// can overwhelm Jellyfin's database and flood Plex with requests.
+        /// </summary>
+        public int MaxConcurrentApiRequests { get; set; }
+
+        /// <summary>
+        /// Gets or sets how long (in milliseconds) Plexyfin pauses between item-artwork batches
+        /// (see <see cref="SyncBatchSize"/>). Set to 0 to disable the pause entirely and move
+        /// straight to the next batch. Higher values are gentler on Plex/Jellyfin but make large
+        /// libraries take longer to sync.
+        /// </summary>
+        public int BatchDelayMilliseconds { get; set; }
         
         /// <summary>
         /// Gets or sets the schedule interval in hours.

--- a/Jellyfin.Plugin.Plexyfin/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Plexyfin/Configuration/configPage.html
@@ -77,7 +77,31 @@
                             <label for="SyncBatchSize">Sync batch size:</label>
                             <input id="SyncBatchSize" name="SyncBatchSize" type="number" min="1" max="500" step="1" required />
                             <div class="fieldDescription" style="font-size: 90%; margin-bottom: 15px;">
-                                Number of items to process in each batch during sync operations. Adjust based on your server's performance and load.
+                                Number of items grouped into one batch during artwork sync. Plexyfin pauses briefly
+                                between batches instead of processing an entire library in one go. This does
+                                <strong>not</strong> control how many items are worked on at the same time &mdash; see
+                                "Max concurrent operations" below for that.
+                            </div>
+                        </div>
+                        <div class="inputContainer">
+                            <label for="MaxConcurrentApiRequests">Max concurrent operations:</label>
+                            <input id="MaxConcurrentApiRequests" name="MaxConcurrentApiRequests" type="number" min="1" max="20" step="1" required />
+                            <div class="fieldDescription" style="font-size: 90%; margin-bottom: 15px;">
+                                How many items Plexyfin works on at the same time during artwork sync (this applies to
+                                movies/shows as well as their seasons and episodes). This is the main setting for how
+                                much simultaneous load is put on your Plex server (concurrent downloads) and on
+                                Jellyfin (concurrent image saves/database writes). <strong>Keep this low (2-5)</strong>
+                                &mdash; higher values can overwhelm Jellyfin's database or flood Plex with requests,
+                                especially on large libraries.
+                            </div>
+                        </div>
+                        <div class="inputContainer">
+                            <label for="BatchDelayMilliseconds">Pause between batches (ms):</label>
+                            <input id="BatchDelayMilliseconds" name="BatchDelayMilliseconds" type="number" min="0" max="60000" step="50" required />
+                            <div class="fieldDescription" style="font-size: 90%; margin-bottom: 15px;">
+                                How long Plexyfin waits between processing batches (see "Sync batch size" above), in
+                                milliseconds. Gives Plex and Jellyfin a short breather so requests aren't sent in one
+                                continuous stream. Set to 0 to disable the pause and move to the next batch immediately.
                             </div>
                         </div>
                         <div class="checkboxContainer">
@@ -123,6 +147,38 @@
                             <span style="font-size: 16px;">⚠️ WARNING</span><br>
                             Enabling artwork sync will <strong>REPLACE ALL EXISTING ARTWORK</strong> in Jellyfin with the artwork from Plex. All existing posters and backdrops in Jellyfin will be deleted and replaced with Plex's artwork. This operation cannot be undone.<br><br>
                             <strong>It is STRONGLY recommended to create a backup of your Jellyfin metadata directory before performing a sync.</strong>
+                        </div>
+
+                        <div class="checkboxContainer">
+                            <label>
+                                <input type="checkbox" id="SkipUnchangedArtwork" />
+                                <span>Skip Re-downloading Unchanged Artwork</span>
+                            </label>
+                        </div>
+                        <div class="fieldDescription" style="margin-left: 25px; font-size: 90%; margin-bottom: 15px;">
+                            When enabled (recommended), Plexyfin compares Plex's "last updated" timestamp for each item
+                            against the local image file's modification date, and skips re-downloading artwork that
+                            hasn't changed since the last sync. This greatly reduces network and disk load on large
+                            libraries. Genuine artwork changes are still detected and synced &mdash; including posters
+                            and backdrops updated dynamically by tools like Kometa (formerly Plex Meta Manager), since
+                            Plex updates its timestamp whenever those tools modify an item's artwork.
+                        </div>
+
+                        <div class="checkboxContainer">
+                            <label>
+                                <input type="checkbox" id="ForceReplaceAllArtwork" />
+                                <span>Force Replace All Artwork</span>
+                            </label>
+                        </div>
+                        <div class="fieldDescription" style="margin-left: 25px; font-size: 90%; margin-bottom: 15px; color: #d9534f; font-weight: bold; border: 1px solid #d9534f; padding: 10px; border-radius: 4px;">
+                            <span style="font-size: 16px;">⚠️ WARNING</span><br>
+                            When enabled, this <strong>overrides "Skip Re-downloading Unchanged Artwork" above</strong> and
+                            re-downloads and replaces every piece of artwork on every sync, even if it hasn't changed.
+                            Use this to force a one-time full refresh &mdash; for example, if you suspect local artwork
+                            has gotten out of sync with Plex.<br><br>
+                            <strong>Remember to turn this back off after your next sync</strong>, otherwise every future
+                            sync will re-download and replace everything again, putting Plexyfin back into the heavy,
+                            high I/O mode this plugin's optimizations exist to avoid.
                         </div>
 
                     </div>
@@ -814,8 +870,12 @@
                     // SyncPlaylists setting removed
                     // DeleteBeforeSync setting removed - collections are now always created precisely
                     config.SyncBatchSize = document.querySelector('#SyncBatchSize').value;
+                    config.MaxConcurrentApiRequests = document.querySelector('#MaxConcurrentApiRequests').value;
+                    config.BatchDelayMilliseconds = document.querySelector('#BatchDelayMilliseconds').value;
                     config.SyncArtwork = document.querySelector('#SyncArtwork').checked;
                     config.SyncItemArtwork = document.querySelector('#SyncItemArtwork').checked;
+                    config.SkipUnchangedArtwork = document.querySelector('#SkipUnchangedArtwork').checked;
+                    config.ForceReplaceAllArtwork = document.querySelector('#ForceReplaceAllArtwork').checked;
                     config.EnableScheduledSync = document.querySelector('#EnableScheduledSync').checked;
                     config.EnableDebugMode = document.querySelector('#EnableDebugMode').checked;
 
@@ -864,8 +924,12 @@
                     // SyncPlaylists setting removed
                     // DeleteBeforeSync setting removed
                     document.querySelector('#SyncBatchSize').value = config.SyncBatchSize || 40;
+                    document.querySelector('#MaxConcurrentApiRequests').value = config.MaxConcurrentApiRequests || 3;
+                    document.querySelector('#BatchDelayMilliseconds').value = (config.BatchDelayMilliseconds !== undefined && config.BatchDelayMilliseconds !== null) ? config.BatchDelayMilliseconds : 750;
                     document.querySelector('#SyncArtwork').checked = config.SyncArtwork;
                     document.querySelector('#SyncItemArtwork').checked = config.SyncItemArtwork || false;
+                    document.querySelector('#SkipUnchangedArtwork').checked = config.SkipUnchangedArtwork !== false;
+                    document.querySelector('#ForceReplaceAllArtwork').checked = config.ForceReplaceAllArtwork || false;
                     document.querySelector('#EnableScheduledSync').checked = config.EnableScheduledSync;
                     document.querySelector('#SyncIntervalHours').value = config.SyncIntervalHours || 24;
                     document.querySelector('#EnableDebugMode').checked = config.EnableDebugMode || false;

--- a/Jellyfin.Plugin.Plexyfin/Jellyfin.Plugin.Plexyfin.csproj
+++ b/Jellyfin.Plugin.Plexyfin/Jellyfin.Plugin.Plexyfin.csproj
@@ -5,8 +5,9 @@
     <RootNamespace>Jellyfin.Plugin.Plexyfin</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <AssemblyVersion>0.6.2.0</AssemblyVersion>
-    <FileVersion>0.6.2.0</FileVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyVersion>0.6.7.0</AssemblyVersion>
+    <FileVersion>0.6.7.0</FileVersion>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 

--- a/Jellyfin.Plugin.Plexyfin/LoggerHelpers.cs
+++ b/Jellyfin.Plugin.Plexyfin/LoggerHelpers.cs
@@ -1291,6 +1291,18 @@ namespace Jellyfin.Plugin.Plexyfin
                 new EventId(204, nameof(_logCompatibilityMethodNotFound)),
                 "Neither GetItemsResult nor GetItemList methods found on ILibraryManager - plugin may not work correctly with this Jellyfin version");
 
+        private static readonly Action<ILogger, string, string, DateTime, DateTime, Exception?> _logSkippingUnchangedArtwork =
+            LoggerMessage.Define<string, string, DateTime, DateTime>(
+                LogLevel.Debug,
+                new EventId(205, nameof(_logSkippingUnchangedArtwork)),
+                "Skipping {ImageType} artwork download for {ItemName}: local file (modified {LocalWriteTimeUtc:u}) is already at least as new as Plex's updatedAt ({PlexUpdatedAtUtc:u})");
+
+        private static readonly Action<ILogger, int, Exception?> _logArtworkSkippedSummary =
+            LoggerMessage.Define<int>(
+                LogLevel.Information,
+                new EventId(206, nameof(_logArtworkSkippedSummary)),
+                "Skipped {SkippedCount} unchanged artwork download(s) during this sync");
+
         /// <summary>
         /// Logs plugin version information at startup.
         /// </summary>
@@ -1332,5 +1344,25 @@ namespace Jellyfin.Plugin.Plexyfin
         /// <param name="logger">The logger instance.</param>
         public static void LogCompatibilityMethodNotFound(this ILogger logger) =>
             _logCompatibilityMethodNotFound(logger, null);
+
+        /// <summary>
+        /// Logs that an artwork download was skipped because the local file is already
+        /// up to date relative to Plex's "updatedAt" timestamp for the item.
+        /// </summary>
+        /// <param name="logger">The logger instance.</param>
+        /// <param name="itemName">The name of the item.</param>
+        /// <param name="imageType">The type of image (Primary/Backdrop).</param>
+        /// <param name="localWriteTimeUtc">The local file's last write time (UTC).</param>
+        /// <param name="plexUpdatedAtUtc">Plex's reported updatedAt time (UTC).</param>
+        public static void LogSkippingUnchangedArtwork(this ILogger logger, string itemName, string imageType, DateTime localWriteTimeUtc, DateTime plexUpdatedAtUtc) =>
+            _logSkippingUnchangedArtwork(logger, imageType, itemName, localWriteTimeUtc, plexUpdatedAtUtc, null);
+
+        /// <summary>
+        /// Logs a summary of how many artwork downloads were skipped during a sync run.
+        /// </summary>
+        /// <param name="logger">The logger instance.</param>
+        /// <param name="skippedCount">The number of artwork downloads that were skipped.</param>
+        public static void LogArtworkSkippedSummary(this ILogger logger, int skippedCount) =>
+            _logArtworkSkippedSummary(logger, skippedCount, null);
     }
 }

--- a/Jellyfin.Plugin.Plexyfin/Plex/PlexClient.cs
+++ b/Jellyfin.Plugin.Plexyfin/Plex/PlexClient.cs
@@ -134,7 +134,8 @@ namespace Jellyfin.Plugin.Plexyfin.Plex
                         Id = directory.Attribute("ratingKey")?.Value ?? string.Empty,
                         Title = directory.Attribute("title")?.Value ?? string.Empty,
                         SortTitle = directory.Attribute("titleSort")?.Value ?? string.Empty,
-                        Summary = directory.Attribute("summary")?.Value ?? string.Empty
+                        Summary = directory.Attribute("summary")?.Value ?? string.Empty,
+                        UpdatedAt = ParseUpdatedAt(directory)
                     };
                     
                     // Set thumbnail URL if available
@@ -225,7 +226,8 @@ namespace Jellyfin.Plugin.Plexyfin.Plex
                     {
                         Id = element.Attribute("ratingKey")?.Value ?? string.Empty,
                         Title = element.Attribute("title")?.Value ?? string.Empty,
-                        Type = element.Attribute("type")?.Value ?? "movie"
+                        Type = element.Attribute("type")?.Value ?? "movie",
+                        UpdatedAt = ParseUpdatedAt(element)
                     };
                     
                     // Extract file path from Media/Part elements
@@ -282,7 +284,8 @@ namespace Jellyfin.Plugin.Plexyfin.Plex
                     {
                         Id = element.Attribute("ratingKey")?.Value ?? string.Empty,
                         Title = element.Attribute("title")?.Value ?? string.Empty,
-                        Type = element.Attribute("type")?.Value ?? "show"
+                        Type = element.Attribute("type")?.Value ?? "show",
+                        UpdatedAt = ParseUpdatedAt(element)
                     };
                     
                     // Extract external IDs from Guid elements
@@ -390,7 +393,8 @@ namespace Jellyfin.Plugin.Plexyfin.Plex
                                 ParentIndex = season.Index,
                                 SeriesId = seriesId,
                                 SeriesTitle = season.SeriesTitle,
-                                TvdbId = season.TvdbId // Inherit from parent series
+                                TvdbId = season.TvdbId, // Inherit from parent series
+                                UpdatedAt = ParseUpdatedAt(episodeElement)
                             };
 
                             // Set thumbnail URL if available
@@ -517,7 +521,8 @@ namespace Jellyfin.Plugin.Plexyfin.Plex
                             Index = seasonIndex,
                             SeriesId = seriesId,
                             SeriesTitle = seriesTitle,
-                            TvdbId = seriesTvdbId // Inherit from parent series
+                            TvdbId = seriesTvdbId, // Inherit from parent series
+                            UpdatedAt = ParseUpdatedAt(element)
                         };
 
                         // Set thumbnail URL if available
@@ -641,7 +646,8 @@ namespace Jellyfin.Plugin.Plexyfin.Plex
                             {
                                 Id = element.Attribute("ratingKey")?.Value ?? string.Empty,
                                 Title = element.Attribute("title")?.Value ?? string.Empty,
-                                Type = element.Attribute("type")?.Value ?? "movie"
+                                Type = element.Attribute("type")?.Value ?? "movie",
+                                UpdatedAt = ParseUpdatedAt(element)
                             };
                             
                             // Extract file path from Media/Part elements
@@ -697,7 +703,8 @@ namespace Jellyfin.Plugin.Plexyfin.Plex
                             {
                                 Id = element.Attribute("ratingKey")?.Value ?? string.Empty,
                                 Title = element.Attribute("title")?.Value ?? string.Empty,
-                                Type = element.Attribute("type")?.Value ?? "show"
+                                Type = element.Attribute("type")?.Value ?? "show",
+                                UpdatedAt = ParseUpdatedAt(element)
                             };
                             
                             // Extract external IDs from Guid elements
@@ -797,6 +804,24 @@ namespace Jellyfin.Plugin.Plexyfin.Plex
         /// </summary>
         /// <param name="element">The XML element containing the item data.</param>
         /// <param name="item">The PlexItem to populate with external IDs.</param>
+        /// <summary>
+        /// Parses the "updatedAt" attribute (a Unix epoch timestamp in seconds) from a Plex
+        /// XML element, if present.
+        /// </summary>
+        /// <param name="element">The Plex XML element (Video, Directory, etc.).</param>
+        /// <returns>The parsed timestamp, or null if the attribute is missing or invalid.</returns>
+        private static DateTimeOffset? ParseUpdatedAt(XElement element)
+        {
+            var updatedAtValue = element.Attribute("updatedAt")?.Value;
+            if (!string.IsNullOrEmpty(updatedAtValue) &&
+                long.TryParse(updatedAtValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var updatedAtUnix))
+            {
+                return DateTimeOffset.FromUnixTimeSeconds(updatedAtUnix);
+            }
+
+            return null;
+        }
+
         private void ExtractExternalIds(XElement element, PlexItem item)
         {
             _logger.LogDebug("Extracting external IDs for '{0}'", item.Title);

--- a/Jellyfin.Plugin.Plexyfin/Plex/PlexCollection.cs
+++ b/Jellyfin.Plugin.Plexyfin/Plex/PlexCollection.cs
@@ -43,5 +43,13 @@ namespace Jellyfin.Plugin.Plexyfin.Plex
         /// </summary>
         [JsonPropertyName("artUrl")]
         public Uri? ArtUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp of the last time this collection was updated in Plex.
+        /// Used to determine whether locally cached artwork is still current, so unchanged
+        /// artwork does not need to be re-downloaded on every sync.
+        /// </summary>
+        [JsonPropertyName("updatedAt")]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Plexyfin/Plex/PlexModels.cs
+++ b/Jellyfin.Plugin.Plexyfin/Plex/PlexModels.cs
@@ -72,6 +72,14 @@ namespace Jellyfin.Plugin.Plexyfin.Plex {
         /// </summary>
         [JsonPropertyName("tvdbId")]
         public string? TvdbId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp of the last time this episode was updated in Plex.
+        /// Used to determine whether locally cached artwork is still current, so unchanged
+        /// artwork does not need to be re-downloaded on every sync.
+        /// </summary>
+        [JsonPropertyName("updatedAt")]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
     
     /// <summary>
@@ -163,6 +171,16 @@ namespace Jellyfin.Plugin.Plexyfin.Plex {
         /// </summary>
         [JsonPropertyName("filePath")]
         public string? FilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp of the last time this item was updated in Plex.
+        /// Used to determine whether locally cached artwork is still current, so unchanged
+        /// artwork does not need to be re-downloaded on every sync. This also picks up
+        /// artwork refreshes made by external tools such as Kometa (formerly Plex Meta Manager),
+        /// since Plex bumps this timestamp whenever the item's metadata or images change.
+        /// </summary>
+        [JsonPropertyName("updatedAt")]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 
     /// <summary>
@@ -217,5 +235,13 @@ namespace Jellyfin.Plugin.Plexyfin.Plex {
         /// </summary>
         [JsonPropertyName("tvdbId")]
         public string? TvdbId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp of the last time this season was updated in Plex.
+        /// Used to determine whether locally cached artwork is still current, so unchanged
+        /// artwork does not need to be re-downloaded on every sync.
+        /// </summary>
+        [JsonPropertyName("updatedAt")]
+        public DateTimeOffset? UpdatedAt { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Plexyfin/Plugin.cs
+++ b/Jellyfin.Plugin.Plexyfin/Plugin.cs
@@ -186,7 +186,7 @@ namespace Jellyfin.Plugin.Plexyfin
             // Log version information for diagnostics
             var version = GetType().Assembly.GetName().Version;
             var assemblyVersion = version != null ? version.ToString() : "Unknown";
-            _logger.LogPluginVersionInfo("0.6.2.0", assemblyVersion);
+            _logger.LogPluginVersionInfo("0.6.7.0", assemblyVersion);
 
             // Log configuration (without sensitive data like API keys)
             try


### PR DESCRIPTION
## Problem

Item-artwork sync had no concurrency limit for TV seasons and episodes
at all — a series with 100 episodes would fire 100 simultaneous
downloads against Plex and 100 simultaneous image saves/database
writes against Jellyfin. Combined with `SyncBatchSize` being misused
as the top-level concurrency limit (default 50, configurable up to
500), this could flood both Plex and Jellyfin during a sync.

Every artwork sync also unconditionally re-downloaded and replaced
every poster/backdrop, even when nothing had changed in Plex.

## Changes

- **Skip unchanged artwork**: compares Plex's `updatedAt` timestamp
  for each item against the local image file's `LastWriteTimeUtc`,
  and skips the download if it's already current. Still picks up
  genuine changes, including artwork refreshed by tools like Kometa.
  Enabled by default, toggleable in settings.
- **Force Replace All Artwork**: new option to override the check
  above and force a full re-download on demand.
- **Concurrency limit**: added a shared, configurable
  `MaxConcurrentApiRequests` (default 3) applied consistently to
  movies/shows, seasons, and episodes — replacing the unbounded
  parallelism for seasons/episodes and the batch-size misuse for
  top-level items.
- **Real batching**: items are now processed in actual batches
  (`SyncBatchSize`) with a configurable pause between batches
  (`BatchDelayMilliseconds`, default 750ms, 0 to disable).
- **Build fix**: `File.Exists`/`File.GetLastWriteTimeUtc` were
  unqualified and got resolved to `ControllerBase.File(byte[], string)`
  instead of `System.IO.File` (PlexyfinController inherits
  ControllerBase). Now fully qualified.
- Enabled `<Nullable>enable</Nullable>` to clear ~128 pre-existing
  CS8632 warnings caused by `?` annotations without nullable context.

## Testing

Tested against a live Jellyfin 10.10 server with a large mixed
movie/TV library. Verified:
- Artwork downloads correctly skip when unchanged, and correctly
  re-download when Plex's `updatedAt` advances (including via Kometa).
- No more flooding of Plex/Jellyfin during large-library syncs.
- Build succeeds cleanly (net8.0, Release).

## Note

An earlier iteration of this PR deferred Jellyfin's `UpdateItemAsync`
call until an entire library finished processing, to reduce visible
per-item "rescans." This caused stale item references and
`Unable to save ImageInfo for non existing BaseItem` warnings /
missing posters, so it was reverted — each item's artwork change is
persisted immediately after saving, as before.